### PR TITLE
Bump  minimum java to version 8

### DIFF
--- a/_i18n/en/download.html
+++ b/_i18n/en/download.html
@@ -58,7 +58,7 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="radio">
           <label><input type="radio" class="radio-primary" value="other" name="optOS"/>Other</label>
           <p>For installation on other operating systems (such as FreeBSD and Solaris).<br/>
-          <i>OmegaT can be installed on any operating system capable of running version 8 of the Java runtime environment.</i></p>
+          <i>OmegaT can be installed on any operating system capable of running version 1.8 of the Java runtime environment.</i></p>
         </div>
       </div>
       <div class="tab-pane fade" id="tab-jre">
@@ -69,7 +69,7 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="with-linux-jre" style="display:none;">
           <p>OmegaT will usually run on any Linux system on which a
           suitable version of the Java Runtime Environment (JRE) can be be
-          installed. OmegaT currently requires version 8 of the JRE or
+          installed. OmegaT currently requires version 1.8 of the JRE or
           later. To check what version of the JRE, if any, is installed on
           your Linux system, open a console (command-line window) and
           type:</p>

--- a/_i18n/en/download.html
+++ b/_i18n/en/download.html
@@ -58,7 +58,7 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="radio">
           <label><input type="radio" class="radio-primary" value="other" name="optOS"/>Other</label>
           <p>For installation on other operating systems (such as FreeBSD and Solaris).<br/>
-          <i>OmegaT can be installed on any operating system capable of running version 1.6 of the Java runtime environment.</i></p>
+          <i>OmegaT can be installed on any operating system capable of running version 8 of the Java runtime environment.</i></p>
         </div>
       </div>
       <div class="tab-pane fade" id="tab-jre">
@@ -69,7 +69,7 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="with-linux-jre" style="display:none;">
           <p>OmegaT will usually run on any Linux system on which a
           suitable version of the Java Runtime Environment (JRE) can be be
-          installed. OmegaT currently requires version 1.6 of the JRE or
+          installed. OmegaT currently requires version 8 of the JRE or
           later. To check what version of the JRE, if any, is installed on
           your Linux system, open a console (command-line window) and
           type:</p>


### PR DESCRIPTION
OmeaT 4.3.2 configured to be compatible with java 1.8, so update download page to point java 8 as minimum version.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>