### PR TITLE
Drop obsolete entry

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -44,7 +44,6 @@ titles:
      ms_translator: Howto - Using Microsoft Translator in OmegaT
      new_filter: Howto - Creating a new file filter
      preview: Howto - Adding a preview function to OmegaT
-     priorview: Howto - The "Priorview" preview utility
      prop12m: Propagation and one-to-many matching HowTo
      spelling: Howto - Spellchecking
      text_export: Howto - Using the OmegaT text export function (scripting interface)


### PR DESCRIPTION
Here drop `priorview` entry from yaml because
c7bfa5c97cc5721c0111a86b54480827077ecd69 drops
`priorview.html` file.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>