### PR TITLE
Change "OS X" to "macOS"

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -54,11 +54,10 @@ titles:
 windows_jre: Windows with JRE
 windows_jre64b: Windows with 64-bit JRE
 windows_nojre: Windows without JRE
-osx_signed: OS X Notarized
-osx_unsigned: OS X Unsigned
+osx_signed: macOS Notarized
+osx_unsigned: macOS Unsigned
 linux_jre: Linux with JRE
 linux_jre64b: Linux with 64-bit JRE
 nojre: Cross-platform without JRE
 webstart: Web Start
 source: Source code
-


### PR DESCRIPTION
The former is no longer the official branding, and could be confusing especially to newcomers who expect to see "Mac".