### PR TITLE
Add Link of contribution guide

### DIFF
--- a/_i18n/en/index.html
+++ b/_i18n/en/index.html
@@ -273,7 +273,7 @@ areas for which further volunteers would be more than welcome!</p>
         </span>
         <h3>Programming (Java)</h3>
         <p>OmegaT is written in Java. If you're a programmer, and you happen to know Java,
-          please check <a href="https://omegat.readthedocs.io/en/latest/">OmegaT contribution guide</a>,
+          please check the <a href="https://omegat.readthedocs.io/en/latest/">OmegaT contribution guide</a>,
           or its document source text in the <a href="download#downloadTrunk">source code</a> under
           /docs_devel for information on how to get started.</p>
       </div>

--- a/_i18n/en/index.html
+++ b/_i18n/en/index.html
@@ -272,9 +272,10 @@ areas for which further volunteers would be more than welcome!</p>
           <!---->
         </span>
         <h3>Programming (Java)</h3>
-        <p>OmegaT is written in Java. If you're a programmer and you happen
-        to know Java, please check the documentation in the <a href="download#downloadTrunk">source code</a> under
-    /docs_devel for information on how to get started.</p>
+        <p>OmegaT is written in Java. If you're a programmer, and you happen to know Java,
+          please check <a href="https://omegat.readthedocs.io/en/latest/">OmegaT contribution guide</a>,
+          or its document source text in the <a href="download#downloadTrunk">source code</a> under
+          /docs_devel for information on how to get started.</p>
       </div>
       <div class="col-sm-6">
         <span class="glyphicon glyphicon-cog">


### PR DESCRIPTION
We now have a contribution guide on https://omegat.readthedocs.io/en/latest/
This PR is to add a link to a clause for java programmer.