### PR TITLE
final fixes for the DL selector

### DIFF
--- a/_i18n/ar/download.html
+++ b/_i18n/ar/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/ar/download.html
+++ b/_i18n/ar/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/ca/download.html
+++ b/_i18n/ca/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">selector de baixades</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tipus d'instal·lació</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versió</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Sistema operatiu</a>
             </li>
             <li>

--- a/_i18n/ca/download.html
+++ b/_i18n/ca/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">selector de baixades</a>.</p>
         <h3><a id="wizard-result-version" href="#">versió</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Baixa</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Si aquesta versió no està disponible, podeu provar de <a href="#" id="wizard-result-unsigned">baixar la versió sense signar</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/co/download.html
+++ b/_i18n/co/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">Selettore di scaricamentu</a>.</p
         <h3><a id="wizard-result-version" href="#">qualchì versione</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Scaricà</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>S’è sta versione ùn hè micca dispunibule, pudete pruvà di <a href="#" id="wizard-result-unsigned">scaricà a versione senza firma</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/co/download.html
+++ b/_i18n/co/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Selettore di scaricamentu</a>.</p
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tipu d’installazione</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versione</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Sistema d’operazione</a>
             </li>
             <li>

--- a/_i18n/cs/download.html
+++ b/_i18n/cs/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Průvodce stažením</a></p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Typ instalace</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Verze</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operační systémy</a>
             </li>
             <li>

--- a/_i18n/cs/download.html
+++ b/_i18n/cs/download.html
@@ -78,9 +78,11 @@ href="#download-wizard" data-toggle="collapse">Průvodce stažením</a></p>
         <p>Na základě vašich voleb doporučujeme použít:</p>
         <h3><a id="wizard-result-version" href="#">nějaká verze</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Stažení</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Pokud tato verze není dostupná, můžete zkusit <a href="#" id="wizard-result-unsigned">stáhnout nepodepsanou verzi</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/cz/download.html
+++ b/_i18n/cz/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/cz/download.html
+++ b/_i18n/cz/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/de/download.html
+++ b/_i18n/de/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">Download-Selektor</a> verwenden.<
         <h3><a id="wizard-result-version" href="#">Irgendeine Version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Wenn diese Version nicht verfügbar ist, können Sie versuchen, <a href="#" id="wizard-result-unsigned">die unsignierte Version herunterzuladen</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/de/download.html
+++ b/_i18n/de/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Download-Selektor</a> verwenden.<
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installationstyp</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Betriebssystem</a>
             </li>
             <li>

--- a/_i18n/el/download.html
+++ b/_i18n/el/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/el/download.html
+++ b/_i18n/el/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/en/download.html
+++ b/_i18n/en/download.html
@@ -100,9 +100,11 @@ Currently, we offer only a Standard version.</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/es/download.html
+++ b/_i18n/es/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Selector de descarga</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tipo de instalación</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versión</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Sistema operativo</a>
             </li>
             <li>

--- a/_i18n/es/download.html
+++ b/_i18n/es/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">Selector de descarga</a>.</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Descargar</a>
 	
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Si esta versión no está disponible, puede intentar <a href="#" id="wizard-result-unsigned">descargar la versión sin firmar</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/fi/download.html
+++ b/_i18n/fi/download.html
@@ -78,9 +78,11 @@ href="#download-wizard" data-toggle="collapse">latausvalitsinta</a>.</p>
         <h3><a id="wizard-result-version" href="#">joku versio</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Lataa</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Jos tätä versiota ei ole saatavilla, voit yrittää <a href="#" id="wizard-result-unsigned">ladata version, jossa ei ole allekirjoitusta</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/fi/download.html
+++ b/_i18n/fi/download.html
@@ -12,12 +12,6 @@ href="#download-wizard" data-toggle="collapse">latausvalitsinta</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Asennuksen tyyppi</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versio</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Käyttöjärjestelmä</a>
             </li>
             <li>

--- a/_i18n/fr/download.html
+++ b/_i18n/fr/download.html
@@ -80,9 +80,11 @@ href="#download-wizard" data-toggle="collapse">Sélecteur de téléchargement</a
         <h3><a id="wizard-result-version" href="#">une certaine version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Télécharger</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Si cette version n’est pas disponible, vous pouvez essayer de <a href="#" id="wizard-result-unsigned">téléchargez la version non signée</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/fr/download.html
+++ b/_i18n/fr/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Sélecteur de téléchargement</a
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Type d’installation</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Système d’exploitation</a>
             </li>
             <li>

--- a/_i18n/gl/download.html
+++ b/_i18n/gl/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/gl/download.html
+++ b/_i18n/gl/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/hr/download.html
+++ b/_i18n/hr/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/hr/download.html
+++ b/_i18n/hr/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/hu/download.html
+++ b/_i18n/hu/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/hu/download.html
+++ b/_i18n/hu/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/ia/download.html
+++ b/_i18n/ia/download.html
@@ -78,9 +78,11 @@ href="#download-wizard" data-toggle="collapse">Selector de discargamento</a>.</p
         <p>In base a tu selectiones, nos te recommenda de usar:</p>
         <h3><a id="wizard-result-version" href="#">alcun version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Discargamento</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Si iste version non es disponibile, tu pote provar a <a href="#" id="wizard-result-unsigned">discargar le version non firmate</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/ia/download.html
+++ b/_i18n/ia/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Selector de discargamento</a>.</p
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Typo de installation</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Systema operative</a>
             </li>
             <li>

--- a/_i18n/id/download.html
+++ b/_i18n/id/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/id/download.html
+++ b/_i18n/id/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/it/download.html
+++ b/_i18n/it/download.html
@@ -78,9 +78,11 @@ href="#download-wizard" data-toggle="collapse">Selettore di scaricamento</a>.</p
         <p>In base alle scelte personali, raccomandiamo l'utilizzo di:</p>
         <h3><a id="wizard-result-version" href="#">una qualche versione</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Scarica</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Se questa versione non è disponibile, è possibile provare a <a href="#" id="wizard-result-unsigned">scaricare la versione non firmata</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/it/download.html
+++ b/_i18n/it/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Selettore di scaricamento</a>.</p
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tipo di installazione</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versione</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Sistema operativo</a>
             </li>
             <li>

--- a/_i18n/ja/download.html
+++ b/_i18n/ja/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">ダウンロードセレクタ</a
         <h3><a id="wizard-result-version" href="#">何らかのバージョン</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> ダウンロード</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>このバージョンが使用できない場合は、<a href="#" id="wizard-result-unsigned">署名のないバージョン</a>をダウンロードしてみてください。</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/ja/download.html
+++ b/_i18n/ja/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">ダウンロードセレクタ</a
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">インストールの種類</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">バージョン</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">オペレーティング・システム</a>
             </li>
             <li>

--- a/_i18n/ko/download.html
+++ b/_i18n/ko/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/ko/download.html
+++ b/_i18n/ko/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/mfe/download.html
+++ b/_i18n/mfe/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">Selekter 'Download'</a>.</p>
         <h3><a id="wizard-result-version" href="#">enn sertin version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> 'Download'</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Si sa version-la pa disponib, ou kapav sey <a href="#" id="wizard-result-unsigned">'download' version non-signe</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/mfe/download.html
+++ b/_i18n/mfe/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Selekter 'Download'</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tip linstalasion</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">'Operating System'</a>
             </li>
             <li>

--- a/_i18n/nl/download.html
+++ b/_i18n/nl/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">Download selecteren</a> gebruiken
         <h3><a id="wizard-result-version" href="#">willekeurige versie</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Downloaden</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Als deze versie niet beschikbaar is, kunt u proberen <a href="#" id="wizard-result-unsigned">de niet-ondertekende versie te downloaden</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/nl/download.html
+++ b/_i18n/nl/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Download selecteren</a> gebruiken
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Type installatie</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versie</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Besturingssysteem</a>
             </li>
             <li>

--- a/_i18n/pl/download.html
+++ b/_i18n/pl/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/pl/download.html
+++ b/_i18n/pl/download.html
@@ -105,9 +105,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/pt/download.html
+++ b/_i18n/pt/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">selector de transferências</a>.<
         <h3><a id="wizard-result-version" href="#">mesma versão</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Transferir</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Se esta versão não estiver disponível, pode tentar <a href="#" id="wizard-result-unsigned">transferir a versão não assinada</a>.</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/pt/download.html
+++ b/_i18n/pt/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">selector de transferências</a>.<
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tipo de instalação</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versão</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Sistema operativo</a>
             </li>
             <li>

--- a/_i18n/pt_BR/download.html
+++ b/_i18n/pt_BR/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">encontre sua versão do OmegaT</a
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Tipo de instalação</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Versão</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Sistema Operacional</a>
             </li>
             <li>

--- a/_i18n/pt_BR/download.html
+++ b/_i18n/pt_BR/download.html
@@ -78,9 +78,11 @@ href="#download-wizard" data-toggle="collapse">encontre sua versão do OmegaT</a
         <p>Com base em suas escolhas, recomendamos que use:</p>
         <h3><a id="wizard-result-version" href="#">alguma versão</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Baixe aqui</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Caso essa versão não esteja disponível, você pode tentar fazer o <a href="#" id="wizard-result-unsigned">download da versão não assinada</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/ru/download.html
+++ b/_i18n/ru/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">выбором варианта �
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Тип установки</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Версия</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Операционная система</a>
             </li>
             <li>

--- a/_i18n/ru/download.html
+++ b/_i18n/ru/download.html
@@ -78,9 +78,11 @@ href="#download-wizard" data-toggle="collapse">выбором варианта �
         <p>Основываясь на ваших ответах, мы рекомендуем вам:</p>
         <h3><a id="wizard-result-version" href="#">какая-то версия</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Загрузка</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Если эта версия недоступна, вы можете попробовать <a href="#" id="wizard-result-unsigned">загрузить неподписанную версию</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/si/download.html
+++ b/_i18n/si/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/si/download.html
+++ b/_i18n/si/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/sk/download.html
+++ b/_i18n/sk/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/sk/download.html
+++ b/_i18n/sk/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/sq/download.html
+++ b/_i18n/sq/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/sq/download.html
+++ b/_i18n/sq/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/sv/download.html
+++ b/_i18n/sv/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/sv/download.html
+++ b/_i18n/sv/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>

--- a/_i18n/uk/download.html
+++ b/_i18n/uk/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">Вибір версії</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Тип встановлення</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Версія</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Операційна система</a>
             </li>
             <li>

--- a/_i18n/uk/download.html
+++ b/_i18n/uk/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">Вибір версії</a>.</p>
         <h3><a id="wizard-result-version" href="#">певна версія</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Завантажити</a>
 	
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>Якщо ця версія недоступна, ви можете спробувати <a href="#" id="wizard-result-unsigned">завантажити незавірену версію</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/zh_CN/download.html
+++ b/_i18n/zh_CN/download.html
@@ -79,9 +79,11 @@ href="#download-wizard" data-toggle="collapse">下载选择器</a>。</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> 下载</a>
 
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>如果该版本不可用，可尝试<a href="#" id="wizard-result-unsigned">下载未签名版本</a>。</p>
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/zh_CN/download.html
+++ b/_i18n/zh_CN/download.html
@@ -13,12 +13,6 @@ href="#download-wizard" data-toggle="collapse">下载选择器</a>。</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">安装类型</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">版本</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">操作系统</a>
             </li>
             <li>

--- a/_i18n/zh_TW/download.html
+++ b/_i18n/zh_TW/download.html
@@ -104,9 +104,11 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <p>Based on your choices, we recommand you use:</p>
         <h3><a id="wizard-result-version" href="#">some version</a></h3>
         <a id="wizard-result-btn" class="btn btn-primary btn-lg" href="#" role="button"><span class="glyphicon glyphicon-download"></span> Download</a>
+<!-- 
         <div id="wizard-result-osx" style="display:none;">
           <p>If this version is not available, you can try to <a href="#" id="wizard-result-unsigned">download the unsigned version</a>.</p> 
         </div>
+ -->
       </div>
     </div>
   </div>

--- a/_i18n/zh_TW/download.html
+++ b/_i18n/zh_TW/download.html
@@ -15,12 +15,6 @@ href="#download-wizard" data-toggle="collapse">Download selector</a>.</p>
         <div class="container">
           <ul class="nav nav-pills">
             <li>
-              <a href="#tab-install-type" data-toggle="tab">Installation Type</a>
-            </li>
-            <li>
-              <a href="#tab-version" data-toggle="tab">Version</a>
-            </li>
-            <li>
               <a href="#tab-operating-system" data-toggle="tab">Operating System</a>
             </li>
             <li>


### PR DESCRIPTION
I removed the useless DL selector tabs (type/version) and commented out the "unsigned" message for macOS DL.