### PR TITLE
Update my plugin project URL

### DIFF
--- a/_i18n/en/resources.html
+++ b/_i18n/en/resources.html
@@ -30,7 +30,7 @@
       </tr>
       <tr>
         <td>
-          <a href="https://codeberg.org/miurahr/omegat-plugin-epwing">EPWING plugin</a>
+          <a href="https://codeberg.org/miurahr/omegat-epwing">EPWING plugin</a>
         </td>
         <td>Provides functionality to read EPWING dictionary format.</td>
       </tr>

--- a/_i18n/en/resources.html
+++ b/_i18n/en/resources.html
@@ -23,14 +23,14 @@
       </tr>
       <tr>
         <td>
-          <a href="https://github.com/miurahr/omegat-textra-plugin">TexTra plugin</a>
+          <a href="https://codeberg.org/miurahr/omegat-textra-plugin">NICT TexTra plugin</a>
         </td>
         <td>Integrates the TexTra neural machine translation engine into OmegaT. The TexTra API is freely provided by NICT,
         Japan government research agency.</td>
       </tr>
       <tr>
         <td>
-          <a href="https://github.com/miurahr/omegat-plugin-epwing">EPWING plugin</a>
+          <a href="https://codeberg.org/miurahr/omegat-plugin-epwing">EPWING plugin</a>
         </td>
         <td>Provides functionality to read EPWING dictionary format.</td>
       </tr>


### PR DESCRIPTION
I've moved my project from GitHub to Codeberg.org. This change  linked URLs to new  places.