### PR TITLE
Bump upload-pages-artifact version - Fixes #108

### DIFF
--- a/.github/workflows/publish_site.yml
+++ b/.github/workflows/publish_site.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload artifact 🚚
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
There's a warning about a change in how this action handles file permissions when moving from v1 to v2. It requires all files to be readable for the user and for "other". I have checked files permissions locally and it all seemed fine.

@brandelune You had 90% of the problem figured out, the missing bit was that we're using v1 (actions/upload-pages-artifact@v1) rather than the current v3, we get the version with the tag v1 in git which would be that one:
https://github.com/actions/upload-pages-artifact/blob/84bb4cd4b733d5c320c9c9cfbc354937524f4d64/action.yml#L72