### PR TITLE
Typo with html entity less than - Fixes #120

### DIFF
--- a/_i18n/es/resources.html
+++ b/_i18n/es/resources.html
@@ -19,7 +19,7 @@
         <td>
           <a href="https://github.com/yoursdearboy/omegat-browser">Plugin para navegador web</a>
         </td>
-        <td>Acceso rápido a sitios web Soporte de sitio web puede ser escrito en Groovy&lt;</td>
+        <td>Acceso rápido a sitios web Soporte de sitio web puede ser escrito en Groovy.</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Hello, I stumbled into this little typo. 
I'm not sure if this is this is the correct way to handle this or if we want to make a change in translation memories instead?
Here is the page where the typo appears:
[https://omegat.org/es/resources](https://omegat.org/es/resources)