### PR TITLE
Remove reference to Twitter/X, reword contact info

### DIFF
--- a/_i18n/en/contact.html
+++ b/_i18n/en/contact.html
@@ -57,13 +57,6 @@ and/or mailing lists.</p>
           <a href="{{ site.data.links.facebook }}">Facebook</a>
         </td>
       </tr>
-<!-- 
-      <tr>
-        <td>
-          <a href="{{ site.data.links.twitter }}">Twitter</a>
-        </td>
-      </tr>
- -->
       <tr>
         <td>
           <a href="{{ site.data.links.irc }}">IRC</a>

--- a/_i18n/en/contact.html
+++ b/_i18n/en/contact.html
@@ -57,19 +57,16 @@ and/or mailing lists.</p>
           <a href="{{ site.data.links.facebook }}">Facebook</a>
         </td>
       </tr>
+<!-- 
       <tr>
         <td>
           <a href="{{ site.data.links.twitter }}">Twitter</a>
         </td>
       </tr>
+ -->
       <tr>
         <td>
-          <a href="{{ site.data.links.telegram }}">Telegram</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="{{ site.data.links.mastodon }}">Mastodon</a>
+          <a href="{{ site.data.links.irc }}">IRC</a>
         </td>
       </tr>
       <tr>
@@ -79,12 +76,7 @@ and/or mailing lists.</p>
       </tr>
       <tr>
         <td>
-          <a href="{{ site.data.links.reddit }}">Reddit</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="{{ site.data.links.irc }}">IRC</a>
+          <a href="{{ site.data.links.mastodon }}">Mastodon</a>
         </td>
       </tr>
       <tr>
@@ -92,12 +84,21 @@ and/or mailing lists.</p>
           <a href="{{ site.data.links.matrix }}">Matrix</a>
         </td>
       </tr>
+      <tr>
+        <td>
+          <a href="{{ site.data.links.reddit }}">Reddit</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="{{ site.data.links.telegram }}">Telegram</a>
+        </td>
+      </tr>
     </tbody>
   </table>
   <br/>
   <h3>Administration</h3>
 
-  <p>Please contact the <a href="mailto:info@omegat.org">OmegaT project manager</a> regarding any point not covered above. For support requests, use the <a href="{{ site.data.links.support }}">recommended support channel</a>.<br/>
-  Please contact the <a href="mailto:webmaster@omegat.org">webmaster</a> for any point regarding specifically the website.</p>
+  <p>For support requests, use the <a href="{{ site.data.links.support }}">recommended support channel</a>. Contact the <a href="mailto:webmaster@omegat.org">webmaster</a> for any point regarding specifically the website. Contact the <a href="mailto:info@omegat.org">OmegaT project manager</a> regarding any point not covered above.</p>
 
 </div>


### PR DESCRIPTION
The Twitter/X account is not used anymore.

The contact info order has been reworded.